### PR TITLE
Adding support for spi::FullDuplex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ readme = "README.md"
 
 [dependencies]
 embedded-hal = "0.2.4"
+nb = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Note that all of the drivers that use the same underlying bus **must** be stored
 resource (e.g. as one larger `struct`) within the RTIC resources. This ensures that RTIC will
 prevent one driver from interrupting another while they are using the same underlying bus.
 
-This crate also provides convenience types for working with `shared-bus` RTIC resources.
+This crate also provides convenience types for working with RTIC resources that use the same
+underlying peripheral bus.
 
 ## Usage Example
 ```rust

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ struct Resources {
     shared_bus_resources: SharedBusResources<BusType>,
 }
 
-#[init] fn init(c: init::Context) -> init::LateResources {
+#[init]
+fn init(c: init::Context) -> init::LateResources {
     let manager = shared_bus_rtic::new!(bus, BusType);
     let device = Device::new(manager.acquire());
     let other_device = OtherDevice::new(manager.acquire());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,10 @@
 //! ```
 
 use core::sync::atomic::{AtomicBool, Ordering};
-use embedded_hal::blocking::{i2c, spi};
+use embedded_hal::{
+    blocking::{self, i2c},
+    spi,
+};
 
 /// A convenience type to use for declaring the underlying bus type.
 pub type SharedBus<T> = &'static CommonBus<T>;
@@ -112,21 +115,41 @@ impl<BUS: i2c::WriteRead> i2c::WriteRead for &CommonBus<BUS> {
     }
 }
 
-impl<BUS: spi::Transfer<u8>> spi::Transfer<u8> for &CommonBus<BUS> {
-    type Error = BUS::Error;
+macro_rules! spi {
+    ($($T:ty),*) => {
+        $(
+        impl<BUS: blocking::spi::Write<$T>> blocking::spi::Write<$T> for &CommonBus<BUS> {
+            type Error = BUS::Error;
 
-    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
-        self.lock(move |bus| bus.transfer(words))
+            fn write(&mut self, words: &[$T]) -> Result<(), Self::Error> {
+                self.lock(|bus| bus.write(words))
+            }
+        }
+
+        impl<BUS: blocking::spi::Transfer<$T>> blocking::spi::Transfer<$T> for &CommonBus<BUS> {
+            type Error = BUS::Error;
+
+            fn transfer<'w>(&mut self, words: &'w mut [$T]) -> Result<&'w [$T], Self::Error> {
+                self.lock(move |bus| bus.transfer(words))
+            }
+        }
+
+        impl<BUS: spi::FullDuplex<$T>> spi::FullDuplex<$T> for &CommonBus<BUS> {
+            type Error = BUS::Error;
+
+            fn read(&mut self) -> nb::Result<$T, Self::Error> {
+                self.lock(|bus| bus.read())
+            }
+
+            fn send(&mut self, word: $T) -> nb::Result<(), Self::Error> {
+                self.lock(|bus| bus.send(word))
+            }
+        }
+        )*
     }
 }
 
-impl<BUS: spi::Write<u8>> spi::Write<u8> for &CommonBus<BUS> {
-    type Error = BUS::Error;
-
-    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        self.lock(|bus| bus.write(words))
-    }
-}
+spi!(u8, u16, u32, u64);
 
 /// Provides a method of generating a shared bus.
 ///


### PR DESCRIPTION
This PR adds support for the `spi::FullDuplex<T>` trait as well as the `blocking::spi::Write<T>` and `blocking::spi::Transfer<T>` traits (instead of just u8 implementations).

This fixes #1 