### PR TITLE
Adding Thumbv6 support and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,3 +32,28 @@ jobs:
         with:
           command: build
           args: --release
+
+  thumbv6:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv6m-none-eabihf
+          override: true
+      - name: Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --verbose
+      - name: Build Debug
+        uses: actions-rs/cargo@v1
+        with:
+          command: build --features thumbv6
+      - name: Build Release
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --features thumbv6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,9 @@ jobs:
       - name: Build Debug
         uses: actions-rs/cargo@v1
         with:
-          command: build --features thumbv6
+          command: build --feature thumbv6
       - name: Build Release
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --features thumbv6
+          args: --release --feature thumbv6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Armv7 Build
+name: Arm Build
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  compile:
+  thumbv7:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: thumbv6m-none-eabihf
+          target: thumbv6m-none-eabi
           override: true
       - name: Check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,10 @@ jobs:
       - name: Build Debug
         uses: actions-rs/cargo@v1
         with:
-          command: build --feature thumbv6
+          command: build
+          args: --features thumbv6
       - name: Build Release
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --feature thumbv6
+          args: --release --features thumbv6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ readme = "README.md"
 
 [dependencies]
 embedded-hal = "0.2.4"
+cortex-m = { version = "0.6", optional = true }
+
+[features]
+thumbv6 = ["cortex-m"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ prevent one driver from interrupting another while they are using the same under
 
 This crate also provides convenience types for working with `shared-bus` RTIC resources.
 
+## Features
+
+This crate is compatible with thumbv6 architectures. To enable support for thumbv6
+devices, enable the `thumbv6` feature in your `Cargo.toml`:
+```
+[dependencies.shared-bus-rtic]
+features = ["thumbv6"]
+```
+
 ## Usage Example
 ```rust
 


### PR DESCRIPTION
This PR fixes #3 by adding support for Thumbv6 by shimming in an atomic bool layer for platforms (thumbv6) that don't support atomic operations. This will have to be completed on a platform-by-platform basis, as we require a means to acquire a critical section.

This follows the design in https://github.com/jamesmunns/bbqueue/blob/38d28a0df2ecb812fac90e31565ff2875696b3dc/core/src/bbbuffer.rs#L984-L1037