### PR TITLE
Remove expect, which would pull in lots of (unnecessary) fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This file contains all changes to the shared-bus-rtic library.
 - TODO
 
 ### Fixed
-- TODO
+- Removed a call to `expect` which pulled in unnecessary fmt bloat
 
 ## [0.2.2] - 2020-07-21
 


### PR DESCRIPTION
See title.

The expect call adds about 1.2KiB of fmt bloat when no other parts of the code use that. Panic! doesn't do any formatting