### PR TITLE
Preparing for crate deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file contains all changes to the shared-bus-rtic library.
 
-## [0.2.3+deprecated]
+## [0.2.3+deprecated] - 2023-07-03
 
 ### Added
 - This crate is now deprecated. Users should use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 This file contains all changes to the shared-bus-rtic library.
 
-## [Unreleased]
+## [0.2.3+deprecated]
 
 ### Added
-- TODO
+- This crate is now deprecated. Users should use
+[`embedded-hal-bus`](https://crates.io/crates/embedded-hal-bus) instead.
 
 ### Fixed
 - Removed a call to `expect` which pulled in unnecessary fmt bloat

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared-bus-rtic"
-version = "0.2.2"
+version = "0.2.3+deprecated"
 authors = ["Ryan Summers <ryan.summers@vertigo-designs.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # shared-bus-rtic
 Provides macros and type definitions for using a shared peripheral bus in an RTIC application
 
+## :warning: Deprecation Notice :warning:
+
+With the release of `embedded-hal` v1.0, this crate is no longer necessary. Instead, users should
+migrate to using `embedded-hal` v1.0 traits alongside the [`embedded-hal-bus`](https://crates.io/crates/embedded-hal-bus).
+
 ## Description
 
 Note that all of the drivers that use the same underlying bus **must** be stored within a single


### PR DESCRIPTION
This fixes #9 by releasing and simultaneously deprecating this crate. Documentation now redirects users to `embedded-hal-bus`.